### PR TITLE
feat!: :sparkles: transaction can now be placed to the context

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ func main() {
   _, err = q.Exec(ctx, "UPDATE table SET something = 1")
   return err
  }, conn.StatementTimeout(time.Second))
+
+tx, err := wrapped.Conn(ctx).Begin(ctx)
+ if err != nil {
+  log.Fatalf("failed to start transaction: %s", err)
+ }
+
+ // Put a transaction in the context, so that all subsequent calls use the transaction
+ txCtx := conn.NewTxContext(ctx, tx)
+ if _, err := wrapped.Exec(txCtx, "UPDATE table SET something = 1"); err != nil {
+  _ = tx.Rollback(ctx)
+  log.Fatalf("failed to exec: %s", err)
+ }
+ if err := wrapped.Get(txCtx, &count, "SELECT COUNT(*) FROM table"); err != nil {
+  _ = tx.Rollback(ctx)
+  log.Fatalf("failed to get: %s", err)
+ }
+
+ if err := tx.Commit(ctx); err != nil {
+  log.Fatalf("failed to commit transaction: %s", err)
+ }
 }
 ```
 

--- a/conn/tx_options.go
+++ b/conn/tx_options.go
@@ -1,7 +1,10 @@
 package conn
 
 import (
+	"context"
 	"time"
+
+	"github.com/jackc/pgx/v4"
 )
 
 const (
@@ -30,4 +33,26 @@ func StatementTimeout(d time.Duration) TxOption {
 	return func(o *TxOptions) {
 		o.StatementTimeout = d.Milliseconds()
 	}
+}
+
+// Context options for transaction
+
+type txKeyType uint8
+
+const (
+	txKey txKeyType = 0
+)
+
+// NewTxContext returns a new context carrying the transaction connection
+func NewTxContext(ctx context.Context, tx pgx.Tx) context.Context {
+	if tx == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, txKey, tx)
+}
+
+// TxFromContext extracts the transaction connection if present.
+func TxFromContext(ctx context.Context) (pgx.Tx, bool) {
+	v, ok := ctx.Value(txKey).(pgx.Tx)
+	return v, ok
 }

--- a/examples/cluster/cluster.go
+++ b/examples/cluster/cluster.go
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	// If needed, one can access the PgxConn to call pgx methods directly such as SendBatch, CopyFrom ... .
-	conn := db.Primary().Conn()
+	conn := db.Primary().Conn(ctx)
 	_ = conn
 	// If needed, one can access the primary or a replica explicitly.
 	primary, replica := db.Primary(), db.Replica()

--- a/rules.mk
+++ b/rules.mk
@@ -166,7 +166,7 @@ go.bumpdeps:
 go.fmt:
 	@set -e; for dir in $(GOMOD_DIRS); do ( set -e; \
 	  cd $$dir; \
-	  $(GO) run mvdan.cc/gofumpt -extra -w -l -s `go list -f '{{.Dir}}' $(WHAT) | grep -v mocks` \
+	  $(GO) run mvdan.cc/gofumpt -extra -w -l `go list -f '{{.Dir}}' $(WHAT) | grep -v mocks` \
 	); done
 
 VERIFY_STEPS += go.depaware-check

--- a/txdb/txdb.go
+++ b/txdb/txdb.go
@@ -132,7 +132,7 @@ func (c *txdbCluster) Replica() conn.Querier {
 
 func (c *txdbCluster) beginOnce(ctx context.Context) (pgx.Tx, error) {
 	if c.tx == nil {
-		tx, err := c.cluster.Primary().Conn().Begin(ctx)
+		tx, err := c.cluster.Primary().Conn(ctx).Begin(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/txdb/txdb_test.go
+++ b/txdb/txdb_test.go
@@ -102,12 +102,12 @@ func TestIntegration_txdb(t *testing.T) {
 			t.Parallel()
 			is := is.New(t)
 
-			t1, t2 := sendBatch(db.Primary().Conn())
+			t1, t2 := sendBatch(db.Primary().Conn(ctx))
 			is.True(!t1.Equal(t2)) // transaction_timestamp not in transaction must be not equal
 
 			txdb := New(db)
 
-			t1, t2 = sendBatch(txdb.Primary().Conn())
+			t1, t2 = sendBatch(txdb.Primary().Conn(ctx))
 			is.True(t1.Equal(t2)) // transaction_timestamp in transaction must be equal
 		})
 	})


### PR DESCRIPTION
Transaction can be placed to the context,  so that all subsequent calls can use the transaction without wrapping all in `Tx` method
Querier.Conn now have context as an argument

<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->
